### PR TITLE
Add GHA for pre-commit to verify code quality

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,22 @@
+name: pre-commit
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9 * * 1"
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        extra_args: --files

--- a/README.md
+++ b/README.md
@@ -83,3 +83,8 @@ To collect data, run:
 ```python
 python scripts/main.py
 ```
+
+## Actions Monitor 🔎
+| **Workflow Name**            | **Description**                                        | **Status**                                                                                                                                                                                                                                                                      |
+|------------------------------|--------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| pre-commit    | Ensures that files all follow the same formatting.       | [![pre-commit](https://github.com/AlexanderKhazatsky/R2D2/actions/workflows/pre-commit.yaml/badge.svg)](https://github.com/AlexanderKhazatsky/R2D2/blob/main/.github/workflows/pre-commit.yaml)          |


### PR DESCRIPTION
This pull request adds a GitHub actions workflow that automatically runs the pre-commit configuration for the project against code files hosted on GitHub. Provides a secondary check to ensure pushed code satisfies the pre-commit config.